### PR TITLE
login not required, allow download with apikey only

### DIFF
--- a/methods.json
+++ b/methods.json
@@ -42,9 +42,6 @@
     "method": "GET"
   },
   "/download": {
-    "opts": {
-      "auth": true
-    },
     "url": "/api/v1/download",
     "method": "POST",
     "body": {


### PR DESCRIPTION
apparently /download endpoint works by simply providing the API key same as other endpoints, so there is no need to require authentication with username and password