### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ os.login({
 
 ### Search for a subtitle
 ```js
-os.subtitle({
+os.subtitles({
   query: 'Steal this film 2006',
 }).then((response) => {
   /* response {


### PR DESCRIPTION
Hi! Very, very new coder here, so sorry if I misunderstood and opened this PR needlessly.

I've been using this API to make a small subtitle downloader for my mom, and got real stuck at the search part, since the README has SUBTITLE as the function name, while in actuality, it's supposed to be SUBTITLES.

At least, it wouldn't work in my machine if I tried by SUBTITLE. Feel free to close this if I got it wrong, no need to explain! Thank you for your work!