### PR TITLE
[bug] Authorization token is option when API key is provided

### DIFF
--- a/opensubtitles.js
+++ b/opensubtitles.js
@@ -93,7 +93,7 @@ module.exports = class OS {
 
     // HEADERS Authorization
     if (method.opts && method.opts.auth) {
-      if (!this._authentication.token && !params.token) throw Error('requires a bearer token, login first')
+      if (!this._authentication.token && !params.token && !this._settings.apikey) throw Error('requires a bearer token, login first')
       req.headers['Authorization'] = 'Bearer ' + (this._authentication.token || params.token)
     }
 

--- a/opensubtitles.js
+++ b/opensubtitles.js
@@ -93,8 +93,9 @@ module.exports = class OS {
 
     // HEADERS Authorization
     if (method.opts && method.opts.auth) {
-      if (!this._authentication.token && !params.token && !this._settings.apikey) throw Error('requires a bearer token, login first')
-      req.headers['Authorization'] = 'Bearer ' + (this._authentication.token || params.token)
+      const token = this._authentication.token || params.token;
+      if (token) req.headers['Authorization'] = 'Bearer ' + token
+      if (!token && !this._settings.apikey) throw Error('requires a bearer token, login first')
     }
 
     // HEADERS Api-Key


### PR DESCRIPTION
It should not throw error for empty bearer token when API key is provided.